### PR TITLE
macho: handle -final_output arg

### DIFF
--- a/src/MachO/Options.zig
+++ b/src/MachO/Options.zig
@@ -42,6 +42,8 @@ const usage =
     \\--entitlements                     Add path to entitlements file for embedding in code signature
     \\-filelist [file[,dirname]]         Specifies a list of files to link. If the optional [dirname] is
     \\                                   specified, it is prepended to each filename in the list file.
+    \\-final_output                      Specify dylib install name if -install_name is not used. This flags
+    \\                                   is used by compiler driver for multiple -arch arguments.
     \\-flat_namespace                    Use flat namespace dylib resolution strategy
     \\-force_load [path]                 Loads all members of the specified static archive library
     \\-framework [name]                  Link against framework
@@ -140,6 +142,7 @@ force_load_objc: bool = false,
 adhoc_codesign: ?bool = null,
 exported_symbols: []const []const u8 = &[0][]const u8{},
 fixup_chains: bool = false, // TODO default should be true but probably depends on the host version
+final_output: ?[]const u8 = null,
 
 pub fn parse(arena: Allocator, args: []const []const u8, ctx: anytype) !Options {
     if (args.len == 0) ctx.fatal(usage ++ "\n", .{cmd});
@@ -374,6 +377,8 @@ pub fn parse(arena: Allocator, args: []const []const u8, ctx: anytype) !Options 
         } else if (p.argLLVM()) |opt| {
             // Skip any LTO flags since we cannot handle it at the moment anyhow.
             std.log.debug("TODO unimplemented -mllvm {s} option", .{opt});
+        } else if (p.arg1("final_output")) |name| {
+            opts.final_output = name;
         } else if (mem.startsWith(u8, p.arg, "-")) {
             try unknown_options.appendSlice(p.arg);
             try unknown_options.append('\n');

--- a/src/MachO/load_commands.zig
+++ b/src/MachO/load_commands.zig
@@ -52,8 +52,7 @@ pub fn calcLoadCommandsSize(macho_file: *MachO, assume_max_path_len: bool) u32 {
     // LC_ID_DYLIB
     if (options.dylib) {
         sizeofcmds += blk: {
-            const emit = options.emit;
-            const install_name = options.install_name orelse emit.sub_path;
+            const install_name = macho_file.getInstallName();
             break :blk calcInstallNameLen(
                 @sizeOf(macho.dylib_command),
                 install_name,
@@ -206,10 +205,10 @@ pub fn writeDylibLC(ctx: WriteDylibLCCtx, writer: anytype) !void {
     }
 }
 
-pub fn writeDylibIdLC(options: *const Options, writer: anytype) !void {
+pub fn writeDylibIdLC(macho_file: *const MachO, writer: anytype) !void {
+    const options = macho_file.options;
     assert(options.dylib);
-    const emit = options.emit;
-    const install_name = options.install_name orelse emit.sub_path;
+    const install_name = macho_file.getInstallName();
     const curr = options.current_version orelse Options.Version.new(1, 0, 0);
     const compat = options.compatibility_version orelse Options.Version.new(1, 0, 0);
     try writeDylibLC(.{


### PR DESCRIPTION
According to [lld](https://reviews.llvm.org/D105449), when clang is invoked with two -arch flags, it will:
1. call the linker driver twice, once for each arch
2. call `lipo` tool to merge two outputs into a single file `emit.sub_path` is the name of the temporary file the linker writes to. `final_output` is the name of the file lipo writes to after the link.